### PR TITLE
[feature] add inactivatedAt to inactive entities

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -160,11 +160,17 @@ type InactiveBid @entity {
   "The recipient of the InactiveBid"
   recipient: User!
 
-  "The timestamp of the block the InactiveBid was created in"
+  "The timestamp of the block the original Bid was created in"
   createdAtTimestamp: BigInt!
 
-  "The number of the block the InactiveBid was created in"
+  "The number of the block the original Bid was created in"
   createdAtBlockNumber: BigInt!
+
+ "The timestamp of the block the original Bid was inactivated in"
+  inactivatedAtTimestamp: BigInt!
+
+  "The number of the block the original Bid was inactivated in"
+  inactivatedAtBlockNumber: BigInt!
 }
 
 type InactiveAsk @entity {
@@ -186,11 +192,17 @@ type InactiveAsk @entity {
   "The owner of the InactiveAsk"
   owner: User!
 
-  "The timestamp of the block the InactiveAsk was created in"
+  "The timestamp of the block the original Ask was created in"
   createdAtTimestamp: BigInt!
 
-  "The number of the block the InactiveAsk was created in"
+  "The number of the block the original Ask was created in"
   createdAtBlockNumber: BigInt!
+
+  "The timestamp of the block the original Ask was inactivated in"
+  inactivatedAtTimestamp: BigInt!
+
+  "The number of the block the original Ask was inactivated in"
+  inactivatedAtBlockNumber: BigInt!
 }
 
 type Currency @entity {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -267,7 +267,9 @@ export function createInactiveAsk(
   currency: Currency,
   owner: string,
   createdAtTimestamp: BigInt,
-  createdAtBlockNumber: BigInt
+  createdAtBlockNumber: BigInt,
+  inactivatedAtTimestamp: BigInt,
+  inactivatedAtBlockNumber: BigInt
 ): InactiveAsk {
   let inactiveAsk = new InactiveAsk(id)
 
@@ -278,6 +280,8 @@ export function createInactiveAsk(
   inactiveAsk.owner = owner
   inactiveAsk.createdAtTimestamp = createdAtTimestamp
   inactiveAsk.createdAtBlockNumber = createdAtBlockNumber
+  inactiveAsk.inactivatedAtTimestamp = inactivatedAtTimestamp
+  inactiveAsk.inactivatedAtBlockNumber = inactivatedAtBlockNumber
 
   inactiveAsk.save()
   return inactiveAsk
@@ -306,7 +310,9 @@ export function createInactiveBid(
   bidder: User,
   recipient: User,
   createdAtTimestamp: BigInt,
-  createdAtBlockNumber: BigInt
+  createdAtBlockNumber: BigInt,
+  inactivatedAtTimestamp: BigInt,
+  inactivatedAtBlockNumber: BigInt
 ): InactiveBid {
   let inactiveBid = new InactiveBid(id)
   inactiveBid.type = type
@@ -317,6 +323,8 @@ export function createInactiveBid(
   inactiveBid.recipient = recipient.id
   inactiveBid.createdAtTimestamp = createdAtTimestamp
   inactiveBid.createdAtBlockNumber = createdAtBlockNumber
+  inactiveBid.inactivatedAtTimestamp = inactivatedAtTimestamp
+  inactiveBid.inactivatedAtBlockNumber = inactivatedAtBlockNumber
 
   inactiveBid.save()
   return inactiveBid

--- a/src/market.ts
+++ b/src/market.ts
@@ -124,6 +124,7 @@ export function handleAskRemoved(event: AskRemoved): void {
       .concat(event.transaction.hash.toHexString())
       .concat('-')
       .concat(event.transactionLogIndex.toString())
+
     createInactiveAsk(
       inactiveAskId,
       media as Media,
@@ -131,6 +132,8 @@ export function handleAskRemoved(event: AskRemoved): void {
       ask.amount,
       currency,
       ask.owner,
+      ask.createdAtTimestamp,
+      ask.createdAtBlockNumber,
       event.block.timestamp,
       event.block.number
     )
@@ -235,6 +238,8 @@ export function handleBidRemoved(event: BidRemoved): void {
     onChainBid.sellOnShare.value,
     bidder,
     recipient,
+    bid.createdAtTimestamp,
+    bid.createdAtBlockNumber,
     event.block.timestamp,
     event.block.number
   )
@@ -312,6 +317,8 @@ export function handleBidFinalized(event: BidFinalized): void {
     onChainBid.sellOnShare.value,
     bidder,
     recipient,
+    bid.createdAtTimestamp,
+    bid.createdAtBlockNumber,
     event.block.timestamp,
     event.block.number
   )

--- a/test/queries.ts
+++ b/test/queries.ts
@@ -98,6 +98,8 @@ export function inactiveAsksByMediaIdQuery(mediaId: string): string {
                 }
                 createdAtTimestamp
                 createdAtBlockNumber
+                inactivatedAtTimestamp
+                inactivatedAtBlockNumber
             }
         }
     `
@@ -125,6 +127,8 @@ export function inactiveBidsByMediaIdQuery(mediaId: string): string {
                 }
                 createdAtTimestamp
                 createdAtBlockNumber
+                inactivatedAtTimestamp
+                inactivatedAtBlockNumber
             }
         }
     `
@@ -178,6 +182,8 @@ export function inactiveBidByIdQuery(id: string): string {
                 }
                 createdAtTimestamp
                 createdAtBlockNumber
+                inactivatedAtTimestamp
+                inactivatedAtBlockNumber
             }
         }
     `

--- a/test/types.ts
+++ b/test/types.ts
@@ -91,6 +91,8 @@ export interface InactiveAsk {
   owner: User
   createdAtTimestamp: BigInt
   createdAtBlockNumber: BigInt
+  inactivatedAtTimestamp: BigInt
+  inactivatedAtBlockNumber: BigInt
 }
 
 export interface InactiveAskQueryResponse {
@@ -112,6 +114,8 @@ export interface InactiveBid {
   recipient: User
   createdAtTimestamp: BigInt
   createdAtBlockNumber: BigInt
+  inactivatedAtTimestamp: BigInt
+  inactivatedAtBlockNumber: BigInt
 }
 
 export interface InactiveBidQueryResponse {


### PR DESCRIPTION
This commit adds two fields `inactivatedAtTimestamp` and inactivatedAtBlockNumber` to both the `InactiveAsk` and `InactiveBid` entities. It also changes the meaning of `createdAtTimestamp` and `createdAtBlockNumber` on inactive entities to mean the time at which the original entity was created. 