### PR TITLE
Adding composite key for AuctionHouse media

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -354,7 +354,7 @@ enum ReserveAuctionStatus {
 }
 
 type ReserveAuction @entity {
-  "<tokenContract>-<tokenId>"
+  "ID of the auction from contract, autoincrementing int"
   id: ID!
 
   "The originating token contract for this auction"
@@ -362,6 +362,9 @@ type ReserveAuction @entity {
 
   "The token ID for this auction"
   tokenId: BigInt!
+
+  "<tokenContract>-<tokenId>"
+  token: String!
 
   "The media for the auction, if it is a zora NFT"
   media: Media

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -462,6 +462,7 @@ export function createReserveAuction(
 
   reserveAuction.tokenId = tokenId
   reserveAuction.tokenContract = tokenContract
+  reserveAuction.token = tokenContract.concat('-').concat(tokenId.toString()) 
   reserveAuction.media = media ? media.id : null
   reserveAuction.approved = false
   reserveAuction.duration = duration


### PR DESCRIPTION
This allows for finding auctions from foreign contracts that are not the same:
```graphql
auctions(where: {token_in: ["0x0203030203-30", "0x30301020030303-40"]}) {
  id
}
```

Which currently isn't possible without multiple separate queries.

```graphql
query Auction1 {
 auctions(where: {tokenContract: "0x30301020030303", tokenId: "40"]}) {
    id
  }
}
query Auction2 {
 auctions(where: {tokenContract: "0x0203030203", tokenId: "30"]}) {
    id
  }
}
```